### PR TITLE
[ISSUE 12] Add support for SonarQube 10.4 'DownloadOnlyWhenRequired' feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [#16](https://github.com/green-code-initiative/ecoCode-java/issues/12) Add support for SonarQube 10.4 "DownloadOnlyWhenRequired" feature
+- [#12](https://github.com/green-code-initiative/ecoCode-java/issues/12) Add support for SonarQube 10.4 "DownloadOnlyWhenRequired" feature
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#16](https://github.com/green-code-initiative/ecoCode-java/issues/12) Add support for SonarQube 10.4 "DownloadOnlyWhenRequired" feature
+
 ### Changed
 
 ### Deleted

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,7 @@
                     <pluginApiMinVersion>${sonarqube.version}</pluginApiMinVersion>
                     <skipDependenciesPackaging>true</skipDependenciesPackaging>
                     <jreMinVersion>${java.version}</jreMinVersion>
+                    <requiredForLanguages>java</requiredForLanguages>
                     <archive>
                         <manifestEntries>
                             <Implementation-Build>${buildNumber}</Implementation-Build>


### PR DESCRIPTION
Changes made to support new SonarQube 10.4 DownloadOnlyWhenRequired feature.

- [x] Minimum version of sonar-packaging-maven-plugin is [1.22.0.705](https://github.com/SonarSource/sonar-packaging-maven-plugin/releases/tag/1.22.0.705) : we have already 1.23.0.740 version.
- [x] Property <requiredForLanguages> added with applicable languages (java)
- [x] Manifest is generated as expected

I have not tested with SonarQube 10.4 yet because of neither docker image 10.4 nor 10.5 available to check.

Closes https://github.com/green-code-initiative/ecoCode-java/issues/12