### PR TITLE
Improve rule EC67 : Handle case when i++ is located within a binary expression

### DIFF
--- a/src/main/java/fr/greencodeinitiative/java/checks/IncrementCheck.java
+++ b/src/main/java/fr/greencodeinitiative/java/checks/IncrementCheck.java
@@ -22,8 +22,10 @@ import java.util.List;
 
 import org.sonar.check.Rule;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.Tree.Kind;
+import org.sonar.plugins.java.api.tree.UnaryExpressionTree;
 import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 
 @Rule(key = "EC67")
@@ -39,6 +41,11 @@ public class IncrementCheck extends IssuableSubscriptionVisitor {
 
     @Override
     public void visitNode(Tree tree) {
+        var unaryExpressionTree = (UnaryExpressionTree) tree;
+
+        if (unaryExpressionTree.parent() instanceof BinaryExpressionTree) {
+            return;
+        }
         reportIssue(tree, MESSAGERULE);
     }
 }

--- a/src/test/files/IncrementCheckBinaryExpression.java
+++ b/src/test/files/IncrementCheckBinaryExpression.java
@@ -15,27 +15,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package fr.greencodeinitiative.java.checks;
-
-import org.junit.jupiter.api.Test;
-import org.sonar.java.checks.verifier.CheckVerifier;
-
-class IncrementCheckTest {
-
-    @Test
-    void test() {
-        CheckVerifier.newVerifier()
-                .onFile("src/test/files/IncrementCheck.java")
-                .withCheck(new IncrementCheck())
-                .verifyIssues();
+class MyClass2 {
+    MyClass(MyClass mc) {
     }
-
-    @Test
-    void incrementCheck_unaryExpressionWithinBinaryExpression_noIssue() {
-        CheckVerifier.newVerifier()
-                .onFile("src/test/files/IncrementCheckBinaryExpression.java")
-                .withCheck(new IncrementCheck())
-                .verifyNoIssues();
+    void unaryExpressionWithinBinaryExpression() {
+        var i = 0;
+        for (int j=0; j < 10; ++j) {
+            System.out.println("test" + i++);
+            System.out.println(2 + i++);
+            System.out.println(2 - i++);
+            System.out.println(2 * i++);
+            System.out.println(2 / i++);
+        }
     }
-
 }


### PR DESCRIPTION
Ignore rule EC67 when i++ is located within a binary expression

Closes #4 